### PR TITLE
review comments

### DIFF
--- a/DMTN-102.tex
+++ b/DMTN-102.tex
@@ -50,9 +50,17 @@ A quantitative review of the key numbers associated with the LSST Alert Stream.
 % % % % % % % % % % % % % % % % % % % % % % % % % % % % % % % % %
 \section{Introduction} \label{sec:intro}
 
-The LSST Data Management System's (DMS) Alert Production (AP) pipeline will process new data as it is obtained by the telescope. Difference Imaging Analysis (DIA) will be performed, and all sources with a signal-to-noise ratio\reqparam{transSNR}\lsrreq{0101}\dmreq{0269}\dmreq{0274} $>$5 (in positive or negative flux) will be considered "detected", instantiate a record in the source catalogs, and generate an alert. Each alert is a packet containing LSST data about the source such as coordinates, photometry, and image cutouts. For a full description of detected sources and alert packet contents, see \citeds{LSE-163}. The LSST alert stream will be delivered to several community-developed brokers, and also accessible to users\footnote{In this case, "users" is restricted to individuals with LSST data rights and access privileges.} via an alert filtering service through the LSST Data Access Centers (DACs). Plans and policies for alert distribution are provided in \citeds{LDM-612}. 
+The LSST Data Management System's (DMS) Alert Production (AP) pipeline will process new data as it is obtained by the telescope. 
+Difference Imaging Analysis (DIA) will be performed, and all sources with a signal-to-noise ratio\reqparam{transSNR}\lsrreq{0101}\dmreq{0269}\dmreq{0274} $>$5 (in positive or negative flux) will be considered "detected", a record will be instantiated in the source catalogs, and an alert generated.
+Each alert is a packet containing LSST data about the source, such as coordinates, photometry, and image cutouts. 
+For a full description of detected sources and alert packet contents, see \citeds{LSE-163}. 
+The LSST alert stream will be delivered to several community-developed brokers, and also accessible to users\footnote{In this case, "users" is restricted to individuals with LSST data rights and access privileges.} via an alert filtering service through the LSST Data Access Centers (DACs). 
+Plans and policies for alert distribution are provided in \citeds{LDM-612}. 
 
-The purpose of this document is to quantitatively inform broker developers, and the broader scientific community planning to use alerts, on the key numbers regarding alert generation, distribution, and access via the LSST alert filtering service. The goals of this document are threefold: (1) to provide all of the key numbers regarding alert generation in one place; (2) to include any and all basis information, assumptions, and derivations that contributed to the key number; and (3) to be clear about whether each key number represents an estimate, a requirement, or a boundary. Wherever possible, the reference to a specific LSST requirement and any relevant requirement parameters are provided in the right-hand column. In this document we use 8 bits per byte (B), and 1024~B per KB, 1024~KB per MB, and so forth.
+The purpose of this document is to quantitatively inform broker developers, and the broader scientific community planning to use alerts, on the key numbers regarding alert generation, distribution, and access via the LSST alert filtering service. 
+The goals of this document are threefold: (1) to provide all of the key numbers regarding alert generation in one place; (2) to include any and all basis information, assumptions, and derivations that contributed to the key number; and (3) to be clear about whether each key number represents an estimate, a requirement, or a boundary. 
+Wherever possible, the reference to a specific LSST requirement and any relevant requirement parameters are provided in the right-hand column. 
+In this document we use 8 bits per byte (B), and 1024~B per KB, 1024~KB per MB, and so forth.
 
 % The resources used in the preparation of this document are as follows:
 % \begin{itemize}
@@ -73,7 +81,7 @@ The purpose of this document is to quantitatively inform broker developers, and 
 
 The concept and existence of the LSST alert stream was first introduced by the highest-level document, the LSST Science Requirements Document \citedsp{LPM-17}, which specifies that information about the detections of transient, variable, and moving objects be released promptly as a data stream. 
 
-
+	
 % % % % % % % % % % % % %
 \subsection{Alert Release Timescale}\label{ssec:OTT1}
 
@@ -91,7 +99,7 @@ An approximate upper limit on the number of standard visits (the equivalent of 3
 
 The value of 10,000 alerts per visit is a formal requirement on the DMS and not a scientific estimate of the intrinsic rate of transients and variables in the universe. However, estimates for the most common transients and variables can be derived from the Science Book \citep{2009arXiv0912.0201L} by making some significant assumptions, as follows:
 \begin{itemize}
-\item Variable Stars: LSST is predicted to observe a total of $\sim$135 million variable stars. Making the simple assumption that 20\% (80\%) of the stars are in extragalactic (Galactic) fields, and that of the $\sim$18,000 deg$^2$ surveyed by LSST, 80\% (20\%) of the fields are extragalactic (Galactic), and that 10\% of all variable stars are detectably variable at any given time\footnote{Since ``detectably variable" means ``significantly different from the template", the value of 10\% does depend on how the template is generated.}, then a typical extragalactic (Galactic) field would yield $\sim$1,800 ($\sim$28,800) alerts per visit. Averaged over all fields, and weighted by 80\% and 20\% of the fields being extragalactic and Galactic, respectively, this is an average of 7,200 alerts per visit.
+\item Variable Stars: LSST is predicted to observe a total of $\sim$135 million variable stars. Making the simple assumption that 20\% (80\%) of the stars are in extragalactic (Galactic) fields, and that of the $\sim$18,000 deg$^2$ surveyed by LSST, 80\% (20\%) of the fields are extragalactic (Galactic), and that 10\% of all variable stars are detectably variable at any given time, then a typical extragalactic (Galactic) field would yield $\sim$1,800 ($\sim$28,800) alerts per visit \footnote{Since ``detectably variable" means ``significantly different from the template", the value of 10\% does depend on how the template is generated.}. Averaged over all fields, and weighted by 80\% and 20\% of the fields being extragalactic and Galactic, respectively, this is an average of 7,200 alerts per visit.
 \item Supernovae: LSST is predicted to observe a total of $\sim$10 million supernovae in 10 years, or $\sim$1 million per year. Since SNe are typically only visible for a few months, there might be $\sim$0.3 million detectable at any given time. Over 15,000 deg$^{2}$ of extragalactic survey area, that's $\sim$20 SNe deg$^{-2}$ or $\sim$200 alerts for SNe per visit.
 \item Active Galactic Nuclei: LSST is predicted to observe millions of AGN. If $\sim$10\% of them are detectably variable at any given time, then the estimate is that $\sim$0.1 million alerts over 15,000 deg$^2$ would generate $\sim$7 alerts deg$^{-2}$, or $\sim$70 alerts per visit for AGN.
 \item Moving Objects: The number of Solar System objects that LSST is predicted to observe is dominated by the 5.5 million main-belt asteroids. Assuming that they are spread evenly over the $\sim$18,000 deg$^2$ survey area (even though they're not, as they're found primarily along the ecliptic) leads to $\sim$3,000 alerts per visit due to moving objects.
@@ -106,8 +114,10 @@ Therefore, astrophysical estimates for the occurrence rates of alerts caused by 
 
 There are no formal requirements regarding the alert packet size. The statement above is an estimate based on the planned content of the alerts as described in Section 3.5 of \citeds{LSE-163}. Simulated alert packets based on the Apache Avro format are at most $\sim$82~KB. This volume represents an alert packet for a variable star with a full 12 month history of detections. The application of gzip compression can further reduce the size of an alert to $\sim$65~KB (JIRA ticket DM-16280). Cutout stamps included in the alert will be at least 30$\times$30 pixels and contain flux (32 bit/pix), variance (32 bit/pix), and mask (16 bit/pix) extensions for both the template and difference image, plus a header of metadata \citedsp{LSE-163}. The stamps alone will contribute $\gtrsim$18~KB to the total size of the uncompressed alert packet (i.e., $\sim$20\%).
 
-{\bf "Lite" Packet Options --} Brokers which plan to do their own source association, compile source catalogs based on alerts, or not use the image stamps might prefer a stream of packets with appropriately reduced information. The LSST DM team currently expects that providing a subset of alert packet contents will be feasible, and brokers may indicate which information they require during the broker proposal process  \citedsp{LDM-612}. As previously mentioned, removing the image stamps would reduce packet size by $\gtrsim$18~KB. Removing the historical records of past detections would also reduce the size of all alert packets. A few of these options might also be available to users of the LSST alert filtering service (\S~\ref{sec:LAFS}). 
-
+{\bf "Lite" Packet Options --} Brokers that plan to do their own source association, compile source catalogs based on alerts, or not use the image stamps might prefer a stream of packets with appropriately reduced information. 
+The LSST DM team is currently open to exploring options for supporting "lite" versions of alert packets; individual brokers may indicate which information they require (or would like removed from the packets in their stream) during the broker proposal process \citedsp{LDM-682}.
+As previously mentioned, removing the image stamps would reduce packet size by $\gtrsim$18~KB. Removing the historical records of past detections would also reduce the size of all alert packets. 
+A few of these options might also be available to users of the LSST alert filtering service (\S~\ref{sec:LAFS}).
 
 % % % % % % % % % % % % %
 \subsection{Alert Stream Data Rate}\label{ssec:data_rate}
@@ -140,15 +150,15 @@ There are no formal requirements on the alerts database volume. The statement ab
 
 Given the requirement in \S~\ref{ssec:OTT1} that 98\% of all alerts be made available within 60 seconds, a visit would be considered "delayed" and count towards that 1\% limit if, and only if, $>$2\% of its alerts were made available with a latency of $>$60 seconds. The requirement that no more than 0.1\% of all science visits fail to generate and/or distribute alerts is integrated over all stages of data handling (i.e., includes failures at any stage of prompt processing).
 
-Assuming $\sim$10 million alerts per night (\S~\ref{ssec:transN}), brokers can rely on the DMS to not exceed an upper limit of 200,000 alerts (2\%) being made available with a latency of $>$60 seconds, and an upper limit of 10,000 alerts (or 1 visit's worth, i.e., 0.1\% of 1,000 visits per night) that fail to be generated and/or made available. In other words, the absolute worst-case scenario for a night --- even though we might not expect it to happen --- which still meets these specifications is if 989 visits all have just under 2\% of their alerts (i.e., up to 197800 alerts) delayed by $>$60 seconds and made available within 24 hours, {\it and} 10 visits (1\%) have all of their alerts made available with $>$60 seconds and $<$24 hours (i.e., are ``delayed" but not ``failed"), {\it and} 1 visit (0.1\%) completely fails to generate and/or make available any alerts.
+Assuming $\sim$10 million alerts per night (\S~\ref{ssec:transN}), brokers can rely on the DMS to not exceed an upper limit of 200,000 alerts (2\%) being made available with a latency of $>$60 seconds, and an upper limit of 10,000 alerts (or 1 visit's worth, i.e., 0.1\% of 1,000 visits per night) that fail to be generated and/or made available. In other words, the absolute worst-case scenario for a night --- even though we might not expect it to happen --- : still meets these specifications is if 989 visits all have just under 2\% of their alerts (i.e., up to 197800 alerts) delayed by $>$60 seconds and made available within 24 hours, {\it and} 10 visits (1\%) have all of their alerts made available with $>$60 seconds and $<$24 hours (i.e., are ``delayed" but not ``failed"), {\it and} 1 visit (0.1\%) completely fails to generate and/or make available any alerts.
 
 
 % % % % % % % % % % % % %
 \subsection{Alert Stream Completeness and Purity}\label{ssec:comp_pure}
 
-{\bf It is a formal requirement that DM derive and supply threshold values\reqparam{transSampleSNR}\reqparam{transCompletenessMin}\reqparam{transPurityMin}\ossreq{0353} for a spuriousness\footnote{In this context, spuriousness is like a real/bogus score.} parameter which can be used to filter alerts into a subsample of transient and variable objects with a given completeness and purity.}
+{\bf It is a formal requirement that DM derive and supply threshold values\reqparam{transSampleSNR}\reqparam{transCompletenessMin}\reqparam{transPurityMin}\ossreq{0353} for a spuriousness\footnote{In this context, spuriousness is like a real/bogus score.} parameter, which can be used to filter alerts into a subsample of transient and variable objects with a given completeness and purity.}
 
-The formal requirement is that DM calculate a spuriousness parameter for all alerts, and derive and supply a spuriousness threshold value that filters the full stream into a subsample of alerts for transient and variable objects\footnote{See also OSS-REQ-0354 for the required parameters for a subsample of moving objects \citedsp{LSE-30}.} which is 90\% complete and 95\% pure for all sources with a signal-to-noise ratio $>$6. While the requirements on purity and completeness are specified as point thresholds, DM expects to provide information to enable users to choose spuriousness threshold values which will filter the stream to a desired level of completeness and purity, thereby reducing the fraction of false positives (sources detected that are not astrophysical in origin) to a level that is appropriate for their science goals. Brokers could request a pre-filtered stream that includes a restriction on spuriousness.
+The formal requirement is that DM calculate a spuriousness parameter for all alerts, and derive and supply a spuriousness threshold value that filters the full stream into a subsample of alerts for transient and variable objects\footnote{See also OSS-REQ-0354 for the required parameters for a subsample of transient and variable objects \citedsp{LSE-30}.} that is 90\% complete and 95\% pure for all sources with a signal-to-noise ratio $>$6. While the requirements on purity and completeness are specified as point thresholds, DM expects to provide information to enable users to choose spuriousness threshold values that can be used to filter the stream to a desired level of completeness and purity, thereby reducing the fraction of false positives (sources detected that are not astrophysical in origin) to a level that is appropriate for their science goals. Brokers could request a pre-filtered stream that includes a restriction on spuriousness.
 
 
 % % % % % % % % % % % % % % % % % % % % % % % % % % % % % % % % %
@@ -164,7 +174,7 @@ The LSST alerts filtering service is a mechanism by which users --- individuals 
 
 {\bf It is a formal requirement that the LSST alert filtering service be able to support\reqparam{numBrokerUsers}\dmreq{0343} at least 100 simultaneous users.}
 
-This requirement is driven by outbound bandwidth limitations from the Data Access Center at the National Center for Supercomputing Applications, and the DM team is currently investigating approaches that would support larger numbers of active users \citedsp{LDM-612}. During LSST Operations, if the total number of simultaneous users is oversubscribed then a proposal process may be instituted \citedsp{LSE-163}.
+This requirement is driven by outbound bandwidth limitations from the Data Access Center at the National Center for Supercomputing Applications (NCSA); the DM team is currently investigating approaches that would support larger numbers of active users \citedsp{LDM-612}. During LSST Operations, if the total number of simultaneous users is oversubscribed then a proposal process may be instituted \citedsp{LSE-163}.
 
 
 % % % % % % % % % % % % %
@@ -176,7 +186,7 @@ Assuming 1,000 visits per night (\S~\ref{ssec:transN}), each user's filter will 
 
 
 % % % % % % % % % % % % %
-\subsection{Alerts Archive}\label{ssec:LAFS_adb}
+\section{Alerts Archive}\label{ssec:LAFS_adb}
 
 {\bf It is a formal requirement that all alerts be stored in an archival database and be available for retrieval.}\ossreq{0185}
 


### PR DESCRIPTION
As discussed, in the section 'Alert Database Volume' please recalculate for 300 days observing time and cite REQ 0080, 0081, and 0082. 

The broker proposal process is LDM-682 not LDM-612. I have updated this but as LDM-682 is note baselined it does not show up. This should be rectified in a few days. 

I moved footnote 4 so that it all appears on page 3 and is not split across 2 pages. 

